### PR TITLE
docs: fix typo in readme for nuxt

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ An array of routes patterns for which redirection should be disabled.
 Add the `redirect-ssl` to the [`serverMiddleware`](https://nuxtjs.org/api/configuration-servermiddleware#usage) array within in the [nuxt.config.js](https://nuxtjs.org/api/configuration-server) file is the preferred usage:
 
 ```js
-import redirectSSL from 'redirectSSL'
+import redirectSSL from 'redirect-ssl'
 
 export default {
   serverMiddleware: [


### PR DESCRIPTION
Small typo fix in the README in the nuxt example.

`import redirectSSL from 'redirect-ssl'` -> `import redirectSSL from 'redirectSsl'`